### PR TITLE
Add Rust project scaffold with modular structure and CLI skeleton (closes #8, #9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "staxping"
+version = "2.0.0"
+edition = "2021"
+description = "Clean, unified network diagnostics CLI"
+license = "MIT"
+repository = "https://github.com/StaxDash/StaxPing"
+
+[[bin]]
+name = "staxping"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,0 +1,54 @@
+use clap::{Parser, Subcommand};
+
+/// StaxPing — Clean, unified network diagnostics CLI
+#[derive(Parser, Debug)]
+#[command(name = "staxping")]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+
+    /// Output as JSON instead of pretty-printed text
+    #[arg(short, long, global = true)]
+    pub json: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Perform a DNS lookup for a hostname
+    Dns {
+        /// Hostname to resolve
+        host: String,
+    },
+    /// Send an ICMP echo request (ping) to a host
+    Icmp {
+        /// Target host to ping
+        host: String,
+    },
+    /// Send an HTTP request and report status
+    Http {
+        /// URL to probe
+        url: String,
+    },
+    /// Run a traceroute to a host
+    Trace {
+        /// Destination host for traceroute
+        host: String,
+    },
+    /// Show version information
+    Version,
+    /// Manage diagnostic tools
+    #[command(subcommand)]
+    Tools(ToolsCommands),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ToolsCommands {
+    /// List available diagnostic tools
+    List,
+    /// Install a specific diagnostic tool
+    Install {
+        /// Name of the tool to install
+        tool: String,
+    },
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,2 @@
+// CLI argument parsing via clap derive
+pub mod args;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,1 @@
+// Core shared logic for StaxPing

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,67 @@
+mod core;
+mod net;
+mod output;
+mod cli;
+mod registry;
+
+use clap::Parser;
+use cli::args::{Cli, Commands, ToolsCommands};
+
+fn main() {
+    let cli = Cli::parse();
+    let json_mode = cli.json;
+
+    match cli.command {
+        Commands::Dns { host } => {
+            if json_mode {
+                println!(r#"{{"command":"dns","host":"{}","status":"not implemented"}}"#, host);
+            } else {
+                println!("🔍 DNS lookup for: {} (not yet implemented)", host);
+            }
+        }
+        Commands::Icmp { host } => {
+            if json_mode {
+                println!(r#"{{"command":"icmp","host":"{}","status":"not implemented"}}"#, host);
+            } else {
+                println!("📡 ICMP ping to: {} (not yet implemented)", host);
+            }
+        }
+        Commands::Http { url } => {
+            if json_mode {
+                println!(r#"{{"command":"http","url":"{}","status":"not implemented"}}"#, url);
+            } else {
+                println!("🌐 HTTP probe: {} (not yet implemented)", url);
+            }
+        }
+        Commands::Trace { host } => {
+            if json_mode {
+                println!(r#"{{"command":"trace","host":"{}","status":"not implemented"}}"#, host);
+            } else {
+                println!("🗺️  Traceroute to: {} (not yet implemented)", host);
+            }
+        }
+        Commands::Version => {
+            if json_mode {
+                println!(r#"{{"name":"staxping","version":"2.0.0"}}"#);
+            } else {
+                println!("staxping v2.0.0 — Network diagnostics CLI");
+            }
+        }
+        Commands::Tools(sub) => match sub {
+            ToolsCommands::List => {
+                if json_mode {
+                    println!(r#"{{"tools":[]}}"#);
+                } else {
+                    println!("🛠️  Available tools: (none installed)");
+                }
+            }
+            ToolsCommands::Install { tool } => {
+                if json_mode {
+                    println!(r#"{{"command":"tools install","tool":"{}","status":"not implemented"}}"#, tool);
+                } else {
+                    println!("📦 Installing tool: {} (not yet implemented)", tool);
+                }
+            }
+        },
+    }
+}

--- a/src/net/dns.rs
+++ b/src/net/dns.rs
@@ -1,0 +1,2 @@
+// DNS resolution module (placeholder)
+pub fn placeholder() {}

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -1,0 +1,2 @@
+// HTTP probe module (placeholder)
+pub fn placeholder() {}

--- a/src/net/icmp.rs
+++ b/src/net/icmp.rs
@@ -1,0 +1,2 @@
+// ICMP ping module (placeholder)
+pub fn placeholder() {}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,0 +1,5 @@
+// Network probing modules: DNS, ICMP, HTTP, traceroute
+pub mod dns;
+pub mod icmp;
+pub mod http;
+pub mod trace;

--- a/src/net/trace.rs
+++ b/src/net/trace.rs
@@ -1,0 +1,2 @@
+// Traceroute module (placeholder)
+pub fn placeholder() {}

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,0 +1,1 @@
+// JSON output formatting (placeholder)

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,3 @@
+// Output formatting: JSON, pretty-print
+pub mod json;
+pub mod pretty;

--- a/src/output/pretty.rs
+++ b/src/output/pretty.rs
@@ -1,0 +1,1 @@
+// Pretty-print output formatting (placeholder)

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,0 +1,1 @@
+// stax.toml registry integration (placeholder)


### PR DESCRIPTION
## What

Sets up the StaxPing 2.x Rust project with a clean modular architecture and a full CLI skeleton.

### #8 — Project Structure
- Initialized Rust binary project with `Cargo.toml` (clap, serde, serde_json deps)
- Module layout:
  - `src/core/` — shared logic
  - `src/net/` — DNS, ICMP, HTTP, traceroute (4 sub-modules)
  - `src/output/` — JSON and pretty-print formatting
  - `src/cli/` — argument parsing via clap derive
  - `src/registry/` — stax.toml integration (placeholder)
- All modules have placeholder `mod.rs` files

### #9 — CLI Skeleton
- Full clap derive-based CLI with subcommands:
  - `staxping dns <host>`
  - `staxping icmp <host>`
  - `staxping http <url>`
  - `staxping trace <host>`
  - `staxping version`
  - `staxping tools list`
  - `staxping tools install <tool>`
- `--json` global flag for machine-readable output
- Commands print placeholder messages with appropriate emoji
- JSON mode outputs structured `{"command":...,"status":"not implemented"}` objects

## Files (14)
```
Cargo.toml
src/main.rs
src/cli/args.rs, mod.rs
src/core/mod.rs
src/net/dns.rs, http.rs, icmp.rs, trace.rs, mod.rs
src/output/json.rs, pretty.rs, mod.rs
src/registry/mod.rs
```

Closes #8
Closes #9